### PR TITLE
Fix/tagformat override

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -19,6 +19,7 @@
         "signale",
         "Signale",
         "Rescoped",
-        "rescoped"
+        "rescoped",
+        "releaserc"
     ]
 }

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ a monorepo.
 
 ### tagFormat
 
-Pre-configures the
-[`tagFormat` option](https://github.com/semantic-release/semantic-release/blob/caribou/docs/usage/configuration.md#tagformat) to
-use the [monorepo git tag format](#how).
+To prevent version conflicts, git tags are created with a namespace that incorporates the name of the package, such as
+`my-package-name@1.0.1`. To change this default setting, specify a
+[tagFormat](https://github.com/semantic-release/semantic-release/blob/caribou/docs/usage/configuration.md#tagformat) key in the
+`.releaserc`.
+
+**Remember**, it's essential to choose a format that ensures each workspace/release is unique.

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
         }
     },
     "dependencies": {
+        "cosmiconfig": "^9.0.0",
         "memize": "^2.1.0",
         "meow": "^13.1.0",
         "package-up": "^5.0.0",
@@ -69,8 +70,8 @@
         "@semantic-release/github": "^9.2.6",
         "@semantic-release/npm": "^11.0.2",
         "@semantic-release/release-notes-generator": "^12.1.0",
-        "@types/eslint": "^8.56.1",
-        "@types/node": "^20.10.8",
+        "@types/eslint": "^8.56.2",
+        "@types/node": "^20.11.0",
         "@types/signale": "^1.4.7",
         "commitizen": "^4.3.0",
         "conventional-changelog-conventionalcommits": "^7.0.2",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@
 
 import { createRequire } from 'node:module'
 
+import { cosmiconfig } from 'cosmiconfig'
 import meow from 'meow'
 import { readPackage } from 'read-pkg'
 import type { Options } from 'semantic-release'
@@ -37,10 +38,12 @@ const cli = meow(`
 async function main(flags = cli.flags) {
     try {
         const monoPackage = await readPackage()
+        const rawSemanticConfig = await cosmiconfig('release').search()
 
         const options: Options = {
-            ...flags,
             tagFormat: `${monoPackage.name}@\${version}`,
+            ...flags,
+            ...rawSemanticConfig?.config,
         }
 
         const monoContext = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1503,11 +1503,12 @@ __metadata:
     "@semantic-release/github": "npm:^9.2.6"
     "@semantic-release/npm": "npm:^11.0.2"
     "@semantic-release/release-notes-generator": "npm:^12.1.0"
-    "@types/eslint": "npm:^8.56.1"
-    "@types/node": "npm:^20.10.8"
+    "@types/eslint": "npm:^8.56.2"
+    "@types/node": "npm:^20.11.0"
     "@types/signale": "npm:^1.4.7"
     commitizen: "npm:^4.3.0"
     conventional-changelog-conventionalcommits: "npm:^7.0.2"
+    cosmiconfig: "npm:^9.0.0"
     cspell: "npm:^8.3.2"
     eslint: "npm:^8.56.0"
     husky: "npm:^8.0.3"
@@ -1902,13 +1903,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/eslint@npm:^8.56.1":
-  version: 8.56.1
-  resolution: "@types/eslint@npm:8.56.1"
+"@types/eslint@npm:^8.56.2":
+  version: 8.56.2
+  resolution: "@types/eslint@npm:8.56.2"
   dependencies:
     "@types/estree": "npm:*"
     "@types/json-schema": "npm:*"
-  checksum: 985fd0293e454c459e672e73857920d0746f2eaae8b9aa13a4078c6d3d8fd0d2272f07f67b7fd9078a52d8fe7e1e61a498944129c0f4bc4c29c9cfa968168f5e
+  checksum: 9e4805e770ea90a561e1f69e5edce28b8f66e92e290705100e853c7c252cf87bef654168d0d47fc60c0effbe4517dd7a8d2fa6d3f04c7f831367d568009fd368
   languageName: node
   linkType: hard
 
@@ -1958,12 +1959,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:^20.10.8":
-  version: 20.10.8
-  resolution: "@types/node@npm:20.10.8"
+"@types/node@npm:^20.11.0":
+  version: 20.11.0
+  resolution: "@types/node@npm:20.11.0"
   dependencies:
     undici-types: "npm:~5.26.4"
-  checksum: 820efb084997bb62635883c820bc00c4bd01c71d66b8191fe8559256d6612f6665bbf682ed700bc55a99d48ff1e646d987c6f51afb3cffdb772f267727706277
+  checksum: 8da60a8ccb65181c3d6f7686ddc5f1b1616cafa14d9e520a866adff82c17cc99336a78dd7ce7bee8f54e2332946f678b0e3aa377fbaaf751d3c05b64600872c6
   languageName: node
   linkType: hard
 
@@ -3338,6 +3339,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cosmiconfig@npm:^9.0.0":
+  version: 9.0.0
+  resolution: "cosmiconfig@npm:9.0.0"
+  dependencies:
+    env-paths: "npm:^2.2.1"
+    import-fresh: "npm:^3.3.0"
+    js-yaml: "npm:^4.1.0"
+    parse-json: "npm:^5.2.0"
+  peerDependencies:
+    typescript: ">=4.9.5"
+  peerDependenciesMeta:
+    typescript:
+      optional: true
+  checksum: 8bdf1dfbb6fdb3755195b6886dc0649a3c742ec75afa4cb8da7b070936aed22a4f4e5b7359faafe03180358f311dbc300d248fd6586c458203d376a40cc77826
+  languageName: node
+  linkType: hard
+
 "cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
@@ -3820,7 +3838,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"env-paths@npm:^2.2.0":
+"env-paths@npm:^2.2.0, env-paths@npm:^2.2.1":
   version: 2.2.1
   resolution: "env-paths@npm:2.2.1"
   checksum: 65b5df55a8bab92229ab2b40dad3b387fad24613263d103a97f91c9fe43ceb21965cd3392b1ccb5d77088021e525c4e0481adb309625d0cb94ade1d1fb8dc17e


### PR DESCRIPTION
This PR adds ability to override git tag format by creating `tagFormat` key in workspace `.releaserc`file and updated dependencies